### PR TITLE
Time is managed by the RTC chip

### DIFF
--- a/DomoWatch.ino
+++ b/DomoWatch.ino
@@ -318,7 +318,7 @@ void setup(){
 
 	Serial.println("Reading RTC ...");
 
-	setLocalTZ();	// Apply local timezone
+//	setLocalTZ();	// Apply local timezone
 
 	ttgo->rtc->check();			// Ensure the RTC is valid (if not use compilation time)
 	ttgo->rtc->syncToSystem();	// sync with ESP32

--- a/DomoWatch.ino
+++ b/DomoWatch.ino
@@ -87,6 +87,15 @@ uint8_t bl_lev;			// Backlight level
 	 */
 bool wakingup = true;
 
+	/* Set local (true) or UTC (false) time zone.
+	 * The RTC is always set to the local time zone BUT the watch itself must be
+	 * able to manage daylight saving time.
+	 */
+
+void setLocalTZ(bool local=true){
+	setenv("TZ", local ? "CET-1CEST-2,M3.5.0/02:00:00,M10.5.0/03:00:00" : "", 1);
+	tzset();
+}
 
 	/*********************
 	*	Sleeping
@@ -149,7 +158,12 @@ void wakeup(){
 
 	ttgo->startLvglTick();
 	ttgo->displayWakeup();
+#if 0
+//	setLocalTZ(false);
 	ttgo->rtc->syncToSystem();
+Serial.printf("<- rtc : %s\n", ttgo->rtc->formatDateTime());
+//	setLocalTZ(true);
+#endif
 
 	gui->updateStepCounter();
 //	gui->updateBatteryLevel();
@@ -185,6 +199,7 @@ void deep_sleep(){
 
 void light_sleep(){
 	ttgo->rtc->syncToRtc();	// In case the time as changed
+// Serial.printf("-> rtc : %s\n", ttgo->rtc->formatDateTime());
 
 	ttgo->stopLvglTick();	// stop Lvgl
 	ttgo->bma->enableStepCountInterrupt(false);	// Step counter will not generate interrupt
@@ -302,8 +317,8 @@ void setup(){
 		*****/
 
 	Serial.println("Reading RTC ...");
-	setenv("TZ", "CET-1CEST-2,M3.5.0/02:00:00,M10.5.0/03:00:00", 1);
-	tzset();
+
+	setLocalTZ();	// Apply local timezone
 
 	ttgo->rtc->check();			// Ensure the RTC is valid (if not use compilation time)
 	ttgo->rtc->syncToSystem();	// sync with ESP32

--- a/DomoWatch.ino
+++ b/DomoWatch.ino
@@ -184,7 +184,7 @@ Serial.printf("<- rtc : %s\n", ttgo->rtc->formatDateTime());
 }
 
 void deep_sleep(){
-	ttgo->rtc->syncToRtc();	// In case the time as changed
+//	ttgo->rtc->syncToRtc();	// In case the time as changed
 
 	ttgo->stopLvglTick();
 	ttgo->displayOff();
@@ -198,7 +198,7 @@ void deep_sleep(){
 }
 
 void light_sleep(){
-	ttgo->rtc->syncToRtc();	// In case the time as changed
+//	ttgo->rtc->syncToRtc();	// In case the time as changed
 // Serial.printf("-> rtc : %s\n", ttgo->rtc->formatDateTime());
 
 	ttgo->stopLvglTick();	// stop Lvgl

--- a/TlDateTime.cpp
+++ b/TlDateTime.cpp
@@ -39,44 +39,31 @@ TlDateTime::TlDateTime( TileView *parent, TileView *cloned ) :
 		/* and date */
 	this->datelabel = new Label( this->cont );
 	this->datelabel->seTexttFont( &Ubuntu_16px );
-	this->datelabel->setText( "??.???? ????" );
+	this->datelabel->setText( "??? ??.????????? ????" );
 	this->datelabel->Align( LV_ALIGN_IN_BOTTOM_MID );
 	this->datelabel->AutoRealign();
 	this->datelabel->setClickable( false );	// Pass click to the parent
 
-#if 0
-LV_IMG_DECLARE(foot_16px);
-lv_obj_t 	*_obj = lv_img_create( lv_scr_act(), NULL );
-lv_obj_align( _obj, NULL, LV_ALIGN_IN_BOTTOM_MID, 0,0 );
-lv_img_set_src( _obj, LV_SYMBOL_DUMMY "Test" );
-Serial.printf(" Obj : %d,%d %dx%d\n", 
-		lv_obj_get_x(_obj), lv_obj_get_y(_obj),
-		lv_obj_get_width(_obj), lv_obj_get_height(_obj)
-);
-
-#if 0
-	Image *tst = new Image( lv_scr_act() );
-	tst->Align( LV_ALIGN_IN_BOTTOM_MID);
-	tst->Set( &foot_16px );
-tst->dumpObj("tst DT");
-#endif
-#endif
 }
 
 void TlDateTime::updateTime( void ){
-	time_t now;
-	struct tm  info;
+	RTC_Date now = ttgo->rtc->getDateTime();
+	uint32_t wday = ttgo->rtc->getDayOfWeek( now.day, now.month, now.year );
 	char buf[64];
 
-	time( &now );
-	localtime_r( &now, &info );
-
-	strftime( buf, sizeof(buf), "%H:%M:%S", &info );
+	sprintf( buf, "%02u:%02u:%02u", now.hour, now.minute, now.second );
 	this->timelabel->setText( buf );
 
-	if(info.tm_yday != this->daynum){
-		this->daynum = info.tm_yday;
-		strftime( buf, sizeof(buf), "%a %d %b %Y", &info );
+	if(now.day != this->daynum){
+			// French translation tables
+		const char *wds[] = { "Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam" };
+		const char *mths[] = {
+			"Janvier", "Février", "Mars", "Avril", "Mai", "Juin",
+			"Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"
+		};
+
+		this->daynum = now.day;
+		sprintf( buf, "%s %d %s %d", wds[wday], now.day, mths[now.month-1], now.year );
 		this->datelabel->setText( buf );
 	}
 }

--- a/TlNetwork.cpp
+++ b/TlNetwork.cpp
@@ -20,15 +20,18 @@ LV_IMG_DECLARE(congelo_32px);
 
 /* Request time synchronisation.
  *
- * It seems, NTP query is done in a background tasks.
+ * NTP query is done in a background tasks.
  * The added value, it doesn't block the GUI while querying.
- * The bad side is I can't set the RTC immediately : it will be done
- * at shutdonw.
  */
+static void time_synchronized(struct timeval *tv){
+	Serial.println("time synchronized");
+	ttgo->rtc->syncToRtc();
+}
+
 static void syncTime( lv_obj_t *, lv_event_t event ){
 	if( event == LV_EVENT_CLICKED ){
 		Serial.println("Time synchronisation requested");
-
+		sntp_set_time_sync_notification_cb( time_synchronized );
 		configTzTime("CET-1CEST-2,M3.5.0/02:00:00,M10.5.0/03:00:00", "pool.ntp.org");
 
 		gui->backToHome();	// Return to time tile

--- a/Version.h
+++ b/Version.h
@@ -13,8 +13,9 @@
 *	21/04/2021 - LF : 0.10 - Add time synchronisation
 *	19/10/2021 - LF : 0.15 - expose reboot cause
 *	21/10/2021 - LF : 0.16 - work on doubleclick
+*	07/11/2021 - LF : 0.17 - retrieve time/date from RTC
 */
 
 #ifndef VERSION_H
-#define VERSION_H "0.1603"
+#define VERSION_H "0.1700"
 #endif

--- a/Version.h
+++ b/Version.h
@@ -17,5 +17,5 @@
 */
 
 #ifndef VERSION_H
-#define VERSION_H "0.1700"
+#define VERSION_H "0.1701"
 #endif

--- a/Version.h
+++ b/Version.h
@@ -17,5 +17,5 @@
 */
 
 #ifndef VERSION_H
-#define VERSION_H "0.1701"
+#define VERSION_H "0.1702"
 #endif

--- a/Version.h
+++ b/Version.h
@@ -17,5 +17,5 @@
 */
 
 #ifndef VERSION_H
-#define VERSION_H "0.1702"
+#define VERSION_H "0.1703"
 #endif

--- a/Version.h
+++ b/Version.h
@@ -16,5 +16,5 @@
 */
 
 #ifndef VERSION_H
-#define VERSION_H "0.1602"
+#define VERSION_H "0.1603"
 #endif


### PR DESCRIPTION
Considering :+1: 
- Time zone is really a nightmare to manage
- the embedded clock of the ESP32 is really drifting

So consequently, the time is managed only by the RTC with is making the code simpler, and the time more accurate.
In addition, it will be easier to manage clock alarm.